### PR TITLE
gruntfile/refactor

### DIFF
--- a/frontend/Gruntfile.js
+++ b/frontend/Gruntfile.js
@@ -1,76 +1,76 @@
 module.exports = function(grunt) {
-	grunt.loadNpmTasks('grunt-contrib-cssmin');
-	grunt.loadNpmTasks('grunt-contrib-sass');
-	grunt.loadNpmTasks('grunt-contrib-watch');
-	grunt.loadNpmTasks('grunt-contrib-uglify');
-	grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-contrib-cssmin');
+  grunt.loadNpmTasks('grunt-contrib-sass');
+  grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-contrib-copy');
 
-grunt.initConfig({
-	pkg: grunt.file.readJSON('package.json'),
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
 
-	//------- CSS Minify -------//
-	cssmin: {
-		combine: {
-		  files: {
-		    '../pimpmycause/static/styles/styles.css': ['css/styles.css']
-		  }
-		}
-	},
-
-	//------- SASS -------//
-	sass: {
-		dist: {
-			files: {
-				'css/styles.css': 'src/sass/styles.scss'
-			}
-		}
-	},
-
-	//------- Watch SASS -> CSS -------//
-	watch: {
-		sass: {
-		  files: 'src/sass/**/**.scss',
-		  tasks: ['sass', 'cssmin']
-		}
-	},
-
-	jspaths: {
-    src: {
-      js: 'src/**/**.js'
+    //------- CSS Minify -------//
+    cssmin: {
+      combine: {
+        files: {
+          '../pimpmycause/static/styles/styles.css': ['css/styles.css']
+        }
+      }
     },
-    dest: {
-      jsMin: '../pimpmycause/static/scripts/pimpmycause.min.js'
-    }
-  },
 
-  //------- JS Minify ------//
-  uglify: {
-    options: {
-      compress: true,
-      mangle: true,
-      sourceMap: true
+    //------- SASS -------//
+    sass: {
+      dist: {
+        files: {
+          'css/styles.css': 'src/sass/styles.scss'
+        }
+      }
     },
-    target: {
-      src: '<%= jspaths.src.js %>',
-      dest: '<%= jspaths.dest.jsMin %>'
-    }
-  },
 
-  //------- copy remaining static files ------//
-  copy: {
-    img: {
-      files: [{
-        expand: true,
-        nonull: true,
-        cwd: 'src/img',
-        src: ['*.{png,jpg,jpeg,svg,gif}'],
-        dest: '../pimpmycause/static/img/',
-        filter: 'isFile'
-      }, ]
-    }
-  },
+    //------- Watch SASS -> CSS -------//
+    watch: {
+      sass: {
+        files: 'src/sass/**/**.scss',
+        tasks: ['sass', 'cssmin']
+      }
+    },
 
-});
+    jspaths: {
+      src: {
+        js: 'src/**/**.js'
+      },
+      dest: {
+        jsMin: '../pimpmycause/static/scripts/pimpmycause.min.js'
+      }
+    },
+
+    //------- JS Minify ------//
+    uglify: {
+      options: {
+        compress: true,
+        mangle: true,
+        sourceMap: true
+      },
+      target: {
+        src: '<%= jspaths.src.js %>',
+        dest: '<%= jspaths.dest.jsMin %>'
+      }
+    },
+
+    //------- copy remaining static files ------//
+    copy: {
+      img: {
+        files: [{
+          expand: true,
+          nonull: true,
+          cwd: 'src/img',
+          src: ['*.{png,jpg,jpeg,svg,gif}'],
+          dest: '../pimpmycause/static/img/',
+          filter: 'isFile'
+        }]
+      }
+    }
+
+  });
 
   grunt.registerTask('default', ['sass', 'cssmin', 'uglify', 'copy']);
 

--- a/frontend/Gruntfile.js
+++ b/frontend/Gruntfile.js
@@ -7,6 +7,7 @@ module.exports = function(grunt) {
 
 grunt.initConfig({
 	pkg: grunt.file.readJSON('package.json'),
+
 	//------- CSS Minify -------//
 	cssmin: {
 		combine: {
@@ -15,6 +16,7 @@ grunt.initConfig({
 		  }
 		}
 	},
+
 	//------- SASS -------//
 	sass: {
 		dist: {
@@ -23,47 +25,53 @@ grunt.initConfig({
 			}
 		}
 	},
+
 	//------- Watch SASS -> CSS -------//
 	watch: {
 		sass: {
 		  files: 'src/sass/**/**.scss',
-		  tasks: ['sass']
+		  tasks: ['sass', 'cssmin']
 		}
 	},
+
 	jspaths: {
-        src: {
-                js: 'src/**/**.js'
-            },
-            dest: {
-                jsMin: '../pimpmycause/static/scripts/pimpmycause.min.js'
-            }
-        },
-    uglify: {
-        options: {
-            compress: true,
-            mangle: true,
-            sourceMap: true
-        },
-        target: {
-            src: '<%= jspaths.src.js %>',
-            dest: '<%= jspaths.dest.jsMin %>'
-        }
+    src: {
+      js: 'src/**/**.js'
     },
-    copy: {
-        img: {
-            files: [{
-                expand: true,
-                nonull: true,
-                cwd: 'src/img',
-                src: ['*.{png,jpg,jpeg,svg,gif}'],
-                dest: '../pimpmycause/static/img/',
-                filter: 'isFile'
-            }, ]
-        }
+    dest: {
+      jsMin: '../pimpmycause/static/scripts/pimpmycause.min.js'
+    }
+  },
+
+  //------- JS Minify ------//
+  uglify: {
+    options: {
+      compress: true,
+      mangle: true,
+      sourceMap: true
     },
-        
+    target: {
+      src: '<%= jspaths.src.js %>',
+      dest: '<%= jspaths.dest.jsMin %>'
+    }
+  },
+
+  //------- copy remaining static files ------//
+  copy: {
+    img: {
+      files: [{
+        expand: true,
+        nonull: true,
+        cwd: 'src/img',
+        src: ['*.{png,jpg,jpeg,svg,gif}'],
+        dest: '../pimpmycause/static/img/',
+        filter: 'isFile'
+      }, ]
+    }
+  },
+
 });
 
-    grunt.registerTask('default', ['sass', 'cssmin', 'uglify']);
+  grunt.registerTask('default', ['sass', 'cssmin', 'uglify', 'copy']);
 
 };

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,8 +1,15 @@
 # Women Hack for Non Profit - Pimp My Cause Rebuild
 
-# Making changes
-1. Run 'grunt' to auto build and view any changes
+## Making changes
 
-# Deploy front end screens only
+#### Updating CSS
+1. Run `grunt watch`. Grunt will auto-compile to CSS as you make changes
+2. Reload the webpage to view changes
+
+#### Building
+1. Run `grunt` to manually compile CSS, uglify JS, and copy the remaining static images
+2. Reload the webpage to view changes
+
+<!-- # Deploy front end screens only
 1. To deploy front end screens only to GitHub pages run `grunt deploy`
-2. View the live screens at http://womenhackfornonprofits.github.io/pimpmycause-rebuild
+2. View the live screens at http://womenhackfornonprofits.github.io/pimpmycause-rebuild -->

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -3,7 +3,7 @@
 ## Making changes
 
 #### Updating CSS
-1. Run `grunt watch`. Grunt will auto-compile to CSS as you make changes
+1. Run `grunt watch`. Grunt will auto-compile Sass to CSS as you make changes
 2. Reload the webpage to view changes
 
 #### Building


### PR DESCRIPTION
Hope it's alright if I do this! It's not technically related to any issues on the board.

Changes:
- `grunt watch` now copies the compiled and minified CSS into the Django static folder as well. This makes it more pleasant to update CSS during development since we no longer need to manually run `grunt` to see a style change - we only need to refresh the page
- fixed default `grunt` task to include `copy`
- added some more comments to briefly explain what the tasks are (in case anyone looking at it is new to grunt!)
- temporarily comment out the stuff about the `grunt deploy` task in the `frontend/readme`. The task doesn't seem to exist anymore?