### PR TITLE
feat: update psycopg2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ django==1.11.5                              # Our web framework
 django-countries==5.2
 dj-database-url==0.4.1
 gunicorn==19.5.0                            # Python WSGI HTTP Server
-psycopg2==2.7.4
+psycopg2-binary==2.8.5
 whitenoise==3.1
 django-custom-user==0.7.0                   # Custom user model to allow user auth via email
 django-s3direct==1.0.3                      # Handles asset uploads to s3


### PR DESCRIPTION
```      
/app/.heroku/python/lib/python2.7/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
```