### PR TITLE
feat: add gdal specific env vars for heroku

### DIFF
--- a/pimpmycause/pimpmycause/settings/__init__.py
+++ b/pimpmycause/pimpmycause/settings/__init__.py
@@ -261,3 +261,10 @@ USE_I18N = False
 USE_L10N = True
 
 USE_TZ = True
+
+########
+# GDAL #
+########
+
+GDAL_LIBRARY_PATH = os.getenv('GDAL_LIBRARY_PATH')
+GEOS_LIBRARY_PATH = os.getenv('GEOS_LIBRARY_PATH')


### PR DESCRIPTION
```       django.core.exceptions.ImproperlyConfigured: Could not find the GDAL library (tried "gdal", "GDAL", "gdal2.1.0", "gdal2.0.0", "gdal1.11.0", "gdal1.10.0", "gdal1.9.0"). Is GDAL installed? If it is, try setting GDAL_LIBRARY_PATH in your settings.
```